### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.0.21+4] - November 8, 2022
+
+* Automated dependency updates
+
+
 ## [1.0.21+3] - November 1, 2022
 
 * Automated dependency updates
@@ -91,6 +96,7 @@
 ## [1.0.7] - May 29th, 2022
 
 * Initial release
+
 
 
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: 'dart_dependency_updater'
 description: 'A package that will scan for dependencies in a Dart repo, update them if needed, and can update the repo with them.'
-version: '1.0.21+3'
+version: '1.0.21+4'
 homepage: 'https://github.com/peiffer-innovations/actions_dart_dependency_updater'
 
 environment: 
@@ -8,10 +8,10 @@ environment:
 
 dependencies: 
   args: '^2.3.1'
-  github: '^9.5.1'
+  github: '^9.6.0'
   http: '^0.13.5'
   intl: '^0.17.0'
-  json_class: '^2.1.2+12'
+  json_class: '^2.1.2+13'
   logging: '^1.1.0'
   meta: '^1.7.0'
   pub_api_client: '^2.2.1'
@@ -20,7 +20,7 @@ dependencies:
   yaml_writer: '^1.0.2'
 
 dev_dependencies: 
-  test: '^1.21.7'
+  test: '^1.22.0'
 
 ignore_updates: 
   - 'archive'


### PR DESCRIPTION
PR created automatically via: https://github.com/peiffer-innovations/actions-dart-dependency-updater


dependencies:
  * `github`: 9.5.1 --> 9.6.0
  * `json_class`: 2.1.2+12 --> 2.1.2+13

dev_dependencies:
  * `test`: 1.21.7 --> 1.22.0


Analysis Successful

