### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.0.22+9] - January 31, 2023
+
+* Automated dependency updates
+
+
 ## [1.0.22+8] - January 24, 2023
 
 * Automated dependency updates
@@ -136,6 +141,7 @@
 ## [1.0.7] - May 29th, 2022
 
 * Initial release
+
 
 
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,28 +1,28 @@
 name: 'dart_dependency_updater'
 description: 'A package that will scan for dependencies in a Dart repo, update them if needed, and can update the repo with them.'
-version: '1.0.22+8'
+version: '1.0.22+9'
 homepage: 'https://github.com/peiffer-innovations/actions_dart_dependency_updater'
 
-environment:
+environment: 
   sdk: '>=2.19.0 <4.0.0'
 
-dependencies:
+dependencies: 
   args: '^2.3.2'
-  github: '^9.7.0'
+  github: '^9.8.0'
   http: '^0.13.5'
   intl: '^0.18.0'
-  json_class: '^2.1.4+1'
-  logging: '^1.1.0'
+  json_class: '^2.1.5+1'
+  logging: '^1.1.1'
   meta: '^1.8.0'
   pub_api_client: '^2.3.0'
   pub_semver: '^2.1.3'
   yaml: '^3.1.1'
   yaml_writer: '^1.0.3'
 
-dev_dependencies:
+dev_dependencies: 
   test: '^1.22.2'
 
-ignore_updates:
+ignore_updates: 
   - 'archive'
   - 'async'
   - 'boolean_selector'


### PR DESCRIPTION
PR created automatically via: https://github.com/peiffer-innovations/actions-dart-dependency-updater


dependencies:
  * `github`: 9.7.0 --> 9.8.0
  * `json_class`: 2.1.4+1 --> 2.1.5+1
  * `logging`: 1.1.0 --> 1.1.1


Analysis Successful

