### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.0.22+23] - May 23, 2023
+
+* Automated dependency updates
+
+
 ## [1.0.22+22] - May 16, 2023
 
 * Automated dependency updates
@@ -206,6 +211,7 @@
 ## [1.0.7] - May 29th, 2022
 
 * Initial release
+
 
 
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: 'dart_dependency_updater'
 description: 'A package that will scan for dependencies in a Dart repo, update them if needed, and can update the repo with them.'
-version: '1.0.22+22'
+version: '1.0.22+23'
 homepage: 'https://github.com/peiffer-innovations/actions_dart_dependency_updater'
 
 environment: 
@@ -9,7 +9,7 @@ environment:
 dependencies: 
   args: '^2.4.1'
   github: '^9.14.0'
-  http: '^0.13.6'
+  http: '^1.0.0'
   intl: '^0.18.1'
   json_class: '^2.2.1+3'
   logging: '^1.1.1'
@@ -20,7 +20,7 @@ dependencies:
   yaml_writer: '^1.0.3'
 
 dev_dependencies: 
-  test: '^1.24.2'
+  test: '^1.24.3'
 
 ignore_updates: 
   - 'archive'


### PR DESCRIPTION
PR created automatically


dependencies:
  * `http`: 0.13.6 --> 1.0.0

dev_dependencies:
  * `test`: 1.24.2 --> 1.24.3


Error!!!
```
Resolving dependencies...


Because pub_api_client >=2.3.0 depends on http ^0.13.5 and dart_dependency_updater depends on http ^1.0.0, pub_api_client >=2.3.0 is forbidden.
So, because dart_dependency_updater depends on pub_api_client ^2.4.0, version solving failed.

```

