### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-## [1.0.22+23] - July 16, 2023
+## [1.1.0] - July 16th, 2023
 
-* Automated dependency updates
+* Brought in `pub_api_client` to be able to depend on http 1.1.0
 
 
 ## [1.0.22+22] - May 16, 2023

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.0.22+23] - July 16, 2023
+
+* Automated dependency updates
+
+
 ## [1.0.22+22] - May 16, 2023
 
 * Automated dependency updates
@@ -206,6 +211,7 @@
 ## [1.0.7] - May 29th, 2022
 
 * Initial release
+
 
 
 

--- a/LICENSE
+++ b/LICENSE
@@ -19,3 +19,30 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+
+--------------------------------------------------------------------------------
+
+The pub_api_client code has the following license:
+
+MIT License
+
+Copyright (c) 2020 Leo Farias
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/bin/update.dart
+++ b/bin/update.dart
@@ -69,7 +69,7 @@ Future<void> main(List<String>? args) async {
     var hasUpdates = false;
 
     final timeout = Duration(
-      minutes: JsonClass.parseInt(parsed['timeout']) ?? 10,
+      minutes: JsonClass.maybeParseInt(parsed['timeout']) ?? 10,
     );
     final dryRun = parsed['dry-run'] == true;
 
@@ -372,7 +372,7 @@ Future<bool> _updateDependencies({
 
     var buildNumber = 0;
     if (version.build.isNotEmpty) {
-      buildNumber = JsonClass.parseInt(version.build.first) ?? 0;
+      buildNumber = JsonClass.maybeParseInt(version.build.first) ?? 0;
     }
     buildNumber++;
 

--- a/lib/src/components/version_scanner.dart
+++ b/lib/src/components/version_scanner.dart
@@ -1,6 +1,6 @@
 import 'package:dart_dependency_updater/dart_dependency_updater.dart';
+import 'package:dart_dependency_updater/src/pub_api_client/pub_api_client.dart';
 import 'package:logging/logging.dart';
-import 'package:pub_api_client/pub_api_client.dart';
 import 'package:pub_semver/pub_semver.dart';
 import 'package:yaml/yaml.dart';
 

--- a/lib/src/pub_api_client/pub_api_client.dart
+++ b/lib/src/pub_api_client/pub_api_client.dart
@@ -1,0 +1,6 @@
+export 'package:oauth2/oauth2.dart' show Credentials;
+
+export 'src/constants.dart';
+export 'src/helpers/exceptions.dart';
+export 'src/models/barrel.dart';
+export 'src/pub_api_client_base.dart';

--- a/lib/src/pub_api_client/src/constants.dart
+++ b/lib/src/pub_api_client/src/constants.dart
@@ -1,0 +1,160 @@
+import 'dart:io';
+
+import 'package:path/path.dart';
+
+import '../pub_api_client.dart';
+
+final kEnvVars = Platform.environment;
+
+/// Credentials json
+File get credentialsFile => File(
+      join(dartConfigHome(), 'pub-credentials.json'),
+    );
+
+/// The pub client's OAuth2 secret.
+/// This isn't actually meant to be kept a secret.
+/// https://github.com/dart-lang/pub/blob/master/lib/src/oauth2.dart
+class PubAuth {
+  const PubAuth._();
+  static String identifier =
+      '818368855108-8grd2eg9tj9f38os6f1urbcvsq399u8n.apps.'
+      'googleusercontent.com';
+  static String secret = 'SWeqj8seoJW0w7_CpEPFLX0K';
+}
+
+final _env = Platform.environment;
+
+Credentials? pubCredentials = _pubCredentials();
+
+Credentials? _pubCredentials() {
+  final credEnv = _env['PUB_CREDENTIALS'];
+  // Get credentials from Env var if it exists
+  if (credEnv != null) {
+    return Credentials.fromJson(credEnv);
+  }
+
+  // If not try to get from credentials file
+  if (!credentialsFile.existsSync()) {
+    return null;
+  }
+  final json = credentialsFile.readAsStringSync();
+  return Credentials.fromJson(json);
+}
+
+String dartConfigHome() => join(_configHome, 'dart');
+
+String get _configHome {
+  if (Platform.isWindows) {
+    final appdata = Platform.environment['APPDATA'];
+    if (appdata == null) {
+      throw EnvironmentNotFoundException(
+        'Environment variable %APPDATA% is not defined!',
+      );
+    }
+    return appdata;
+  }
+
+  if (Platform.isMacOS) {
+    return join(_home, 'Library', 'Application Support');
+  }
+
+  if (Platform.isLinux) {
+    final xdgConfigHome = Platform.environment['XDG_CONFIG_HOME'];
+    if (xdgConfigHome != null) {
+      return xdgConfigHome;
+    }
+    // XDG Base Directory Specification says to use $HOME/.config/ when
+    // $XDG_CONFIG_HOME isn't defined.
+    return join(_home, '.config');
+  }
+
+  // We have no guidelines, perhaps we should just do: $HOME/.config/
+  // same as XDG specification would specify as fallback.
+  return join(_home, '.config');
+}
+
+String get _home {
+  final home = Platform.environment['HOME'];
+  if (home == null) {
+    throw EnvironmentNotFoundException(
+        'Environment variable \$HOME is not defined!');
+  }
+  return home;
+}
+
+class EnvironmentNotFoundException implements Exception {
+  final String message;
+  EnvironmentNotFoundException(this.message);
+  @override
+  String toString() => message;
+}
+
+// ignore: avoid_classes_with_only_static_members
+/// Tags used for filtering package searches
+class PackageTag {
+  /// Filter by publisher
+  static String publisher(String publisher) => 'publisher:$publisher';
+
+  /// Filter by dependency
+  static String dependency(String dependency) => 'dependency:$dependency';
+
+  /// Filter packages that are something
+  static String isTag(String isTag) => 'is:$isTag';
+
+  /// Filter packages by supported platform
+  static String platform(String platform) => 'platform:$platform';
+
+  /// Filter packages by sdk
+  static String sdk(String sdk) => 'sdk:$sdk';
+
+  /// Filter packages by license
+  static String license(String license) => 'license:$license';
+
+  /// Show packages that are something
+  static String show(String show) => 'show:$show';
+
+  /// Filter packages that have something
+  static String has(String has) => 'has:$has';
+
+  /// Supports android platform
+  static String platformAndroid = platform('android');
+
+  /// Supports ios platform
+  static String platformIos = platform('ios');
+
+  /// Supports linux platform
+  static String platformLinux = platform('linux');
+
+  /// Supports macos platform
+  static String platformMacos = platform('macos');
+
+  /// Supports web platform
+  static String platformWeb = platform('web');
+
+  /// Supports windows platform
+  static String platformWindows = platform('windows');
+
+  /// Uses dart sdk
+  static String sdkDart = sdk('dart');
+
+  /// Uses flutter sdk
+  static String sdkFlutter = sdk('flutter');
+
+  /// Uses an OSI approved license
+  static String licenseOsiApproved = license('osi-approved');
+
+  /// Is a flutter favorite
+  static String isFlutterFavorite = isTag('flutter-favorite');
+
+  /// Show unlisted packages
+  static String showUnlisted = show('unlisted');
+
+  /// Is null-safe
+  static String isNullSafe = isTag('null-safe');
+
+  /// Has screenshots
+  static String hasScreenshot = has('screenshot');
+
+  /// Is Dart 3 ready
+  static String isDart3Ready = isTag('dart3-ready');
+}

--- a/lib/src/pub_api_client/src/constants.dart
+++ b/lib/src/pub_api_client/src/constants.dart
@@ -83,8 +83,8 @@ String get _home {
 }
 
 class EnvironmentNotFoundException implements Exception {
-  final String message;
   EnvironmentNotFoundException(this.message);
+  final String message;
   @override
   String toString() => message;
 }

--- a/lib/src/pub_api_client/src/endpoints.dart
+++ b/lib/src/pub_api_client/src/endpoints.dart
@@ -1,0 +1,68 @@
+import 'models/search_order.dart';
+
+/// Pub.dev api Endpoints
+class Endpoint {
+  static const defaultBaseUrl =
+      'https://pub.dartlang.org'; // Use pub.dev instead?
+
+  final String baseUrl;
+  late final String apiUrl;
+  late final String searchUrl;
+  late final String packageUrl;
+  late final String accountUrl;
+
+  /// Constructor for API endpoints based on an [url]
+  Endpoint(String? url) : baseUrl = url ?? defaultBaseUrl {
+    apiUrl = '$baseUrl/api';
+    searchUrl = '$apiUrl/search';
+    packageUrl = '$apiUrl/packages';
+    accountUrl = '$apiUrl/account';
+  }
+
+  /// Package info endpoint
+  String packageInfo(String name) => '$packageUrl/$name';
+
+  /// Package score endpoint
+  String packageScore(String name) => '$packageUrl/$name/score';
+
+  /// Package metrics endpoint
+  String packageMetrics(String name) => '$packageUrl/$name/metrics';
+
+  /// Package options endpoint
+  String packageOptions(String name) => '$packageUrl/$name/options';
+
+  /// Package publisher endpoint
+  String packagePublisher(String name) => '$packageUrl/$name/publisher';
+
+  /// Package documentation endpoint
+  String packageDocumentation(String name) => '$apiUrl/documentation/$name';
+
+  // Not part of API endpoint
+  /// Package versions endpoint
+  String packageVersions(String name) => '$baseUrl/packages/$name.json';
+
+  /// Package version info endpoint
+  String packageVersionInfo(String name, String version) =>
+      '$packageUrl/$name/versions/$version';
+
+  /// Retrieve all package names on pub.dev
+  String get packageNames => '$apiUrl/package-names';
+
+  /// Url to add and remove likes
+  String likePackage(String name) => '$accountUrl/likes/$name';
+
+  /// Liked packages
+  String get likedPackages => '$accountUrl/likes';
+
+  /// Search endpoint
+  String search(
+    String query,
+    int page,
+    SearchOrder sort,
+  ) =>
+      '$searchUrl?q=$query&page=$page&sort=${sort.value}';
+
+  /// Next search page
+  String nextPage(String nextPageUrl) =>
+      nextPageUrl.replaceFirst(defaultBaseUrl, baseUrl);
+}

--- a/lib/src/pub_api_client/src/endpoints.dart
+++ b/lib/src/pub_api_client/src/endpoints.dart
@@ -2,6 +2,13 @@ import 'models/search_order.dart';
 
 /// Pub.dev api Endpoints
 class Endpoint {
+  /// Constructor for API endpoints based on an [url]
+  Endpoint(String? url) : baseUrl = url ?? defaultBaseUrl {
+    apiUrl = '$baseUrl/api';
+    searchUrl = '$apiUrl/search';
+    packageUrl = '$apiUrl/packages';
+    accountUrl = '$apiUrl/account';
+  }
   static const defaultBaseUrl =
       'https://pub.dartlang.org'; // Use pub.dev instead?
 
@@ -10,14 +17,6 @@ class Endpoint {
   late final String searchUrl;
   late final String packageUrl;
   late final String accountUrl;
-
-  /// Constructor for API endpoints based on an [url]
-  Endpoint(String? url) : baseUrl = url ?? defaultBaseUrl {
-    apiUrl = '$baseUrl/api';
-    searchUrl = '$apiUrl/search';
-    packageUrl = '$apiUrl/packages';
-    accountUrl = '$apiUrl/account';
-  }
 
   /// Package info endpoint
   String packageInfo(String name) => '$packageUrl/$name';

--- a/lib/src/pub_api_client/src/helpers/exceptions.dart
+++ b/lib/src/pub_api_client/src/helpers/exceptions.dart
@@ -1,0 +1,65 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:http/http.dart';
+
+class PubClientException implements Exception {
+  final Response _response;
+
+  PubClientException(this._response);
+
+  @override
+  String toString() {
+    final data = jsonDecode(_response.body);
+    final message = data?['error']?['message'];
+
+    return '${_response.reasonPhrase}: $message';
+  }
+}
+
+class BadRequestException extends PubClientException {
+  BadRequestException(Response response) : super(response);
+}
+
+class UnauthorizedException extends PubClientException {
+  UnauthorizedException(Response response) : super(response);
+}
+
+class ForbiddenException extends PubClientException {
+  ForbiddenException(Response response) : super(response);
+}
+
+class NotFoundException extends PubClientException {
+  NotFoundException(Response response) : super(response);
+}
+
+class InternalServerError extends PubClientException {
+  InternalServerError(Response response) : super(response);
+}
+
+class UnknownException extends PubClientException {
+  UnknownException(Response response) : super(response);
+}
+
+/// If `status` code is an exception it will throw a [PubClientException]
+void responseValidOrThrow(Response res) {
+  final status = res.statusCode;
+  // Sucessful request
+  if (status >= 200 && status < 400) {
+    return;
+  }
+  switch (status) {
+    case HttpStatus.forbidden:
+      throw ForbiddenException(res);
+    case HttpStatus.notFound:
+      throw NotFoundException(res);
+    case HttpStatus.unauthorized:
+      throw UnauthorizedException(res);
+    case HttpStatus.badRequest:
+      throw BadRequestException(res);
+    case HttpStatus.internalServerError:
+      throw InternalServerError(res);
+    default:
+      throw UnknownException(res);
+  }
+}

--- a/lib/src/pub_api_client/src/helpers/exceptions.dart
+++ b/lib/src/pub_api_client/src/helpers/exceptions.dart
@@ -4,9 +4,8 @@ import 'dart:io';
 import 'package:http/http.dart';
 
 class PubClientException implements Exception {
-  final Response _response;
-
   PubClientException(this._response);
+  final Response _response;
 
   @override
   String toString() {

--- a/lib/src/pub_api_client/src/helpers/http_client.dart
+++ b/lib/src/pub_api_client/src/helpers/http_client.dart
@@ -1,0 +1,20 @@
+import 'package:http/http.dart' as http;
+
+// import 'package:oauth2/oauth2.dart';
+
+import '../version.dart';
+
+class PubApiHttpClient extends http.BaseClient {
+  final http.Client _inner;
+  // final Credentials? credentials;
+  PubApiHttpClient(this._inner);
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) {
+    request.headers['user-agent'] = 'package:pub_client/$packageVersion';
+    // if (credentials != null) {
+    //   request.headers['authorization'] = 'Bearer ${credentials!.idToken}';
+    // }
+    return _inner.send(request);
+  }
+}

--- a/lib/src/pub_api_client/src/helpers/http_client.dart
+++ b/lib/src/pub_api_client/src/helpers/http_client.dart
@@ -5,9 +5,9 @@ import 'package:http/http.dart' as http;
 import '../version.dart';
 
 class PubApiHttpClient extends http.BaseClient {
-  final http.Client _inner;
   // final Credentials? credentials;
   PubApiHttpClient(this._inner);
+  final http.Client _inner;
 
   @override
   Future<http.StreamedResponse> send(http.BaseRequest request) {

--- a/lib/src/pub_api_client/src/helpers/recursive_paging.dart
+++ b/lib/src/pub_api_client/src/helpers/recursive_paging.dart
@@ -1,0 +1,15 @@
+import '../models/search_results_model.dart';
+import '../pub_api_client_base.dart';
+
+Future<List<PackageResult>> recursivePaging(
+    PubClient client, SearchResults prevResults) async {
+  final packages = [...prevResults.packages];
+  final nextPage = prevResults.next;
+  if (nextPage != null) {
+    final results = await client.nextPage(nextPage);
+    final nextResults = await recursivePaging(client, results);
+    packages.addAll(nextResults);
+  }
+
+  return packages;
+}

--- a/lib/src/pub_api_client/src/models/barrel.dart
+++ b/lib/src/pub_api_client/src/models/barrel.dart
@@ -1,0 +1,8 @@
+export 'package_documentation_model.dart';
+export 'package_metrics_model.dart';
+export 'package_options_model.dart';
+export 'package_publisher_model.dart';
+export 'package_score_model.dart';
+export 'pub_package_model.dart';
+export 'search_order.dart';
+export 'search_results_model.dart';

--- a/lib/src/pub_api_client/src/models/latest_version_model.dart
+++ b/lib/src/pub_api_client/src/models/latest_version_model.dart
@@ -1,17 +1,19 @@
+import 'package:meta/meta.dart';
+
 import 'pub_package_model.dart';
 
 /// Latest Version update for package
+@immutable
 class LatestVersion {
-  final bool needUpdate;
-  final String latestVersion;
-  final PubPackage packageInfo;
-
   /// Constructor
   LatestVersion({
     required this.needUpdate,
     required this.latestVersion,
     required this.packageInfo,
   });
+  final bool needUpdate;
+  final String latestVersion;
+  final PubPackage packageInfo;
 
   @override
   bool operator ==(Object other) {

--- a/lib/src/pub_api_client/src/models/latest_version_model.dart
+++ b/lib/src/pub_api_client/src/models/latest_version_model.dart
@@ -1,0 +1,29 @@
+import 'pub_package_model.dart';
+
+/// Latest Version update for package
+class LatestVersion {
+  final bool needUpdate;
+  final String latestVersion;
+  final PubPackage packageInfo;
+
+  /// Constructor
+  LatestVersion({
+    required this.needUpdate,
+    required this.latestVersion,
+    required this.packageInfo,
+  });
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is LatestVersion &&
+        other.needUpdate == needUpdate &&
+        other.latestVersion == latestVersion &&
+        other.packageInfo == packageInfo;
+  }
+
+  @override
+  int get hashCode =>
+      needUpdate.hashCode ^ latestVersion.hashCode ^ packageInfo.hashCode;
+}

--- a/lib/src/pub_api_client/src/models/package_documentation_model.dart
+++ b/lib/src/pub_api_client/src/models/package_documentation_model.dart
@@ -1,0 +1,103 @@
+import 'dart:convert';
+
+import 'package:collection/collection.dart';
+
+/// Package Documentation Model
+
+class PackageDocumentation {
+  final String name;
+
+  final String latestStableVersion;
+
+  final List<PackageDocumentationVersion> versions;
+
+  PackageDocumentation({
+    required this.name,
+    required this.latestStableVersion,
+    this.versions = const [],
+  });
+
+  Map<String, dynamic> toMap() => {
+        'name': name,
+        'latestStableVersion': latestStableVersion,
+        'versions': versions.map((x) => x.toMap()).toList(),
+      };
+
+  factory PackageDocumentation.fromMap(Map<String, dynamic> map) {
+    final versionMap = map['versions'] as List<dynamic>? ?? [];
+
+    return PackageDocumentation(
+      name: map['name'] as String? ?? '',
+      latestStableVersion: map['latestStableVersion'] as String? ?? '',
+      versions: versionMap
+          .map((x) =>
+              PackageDocumentationVersion.fromMap(x as Map<String, dynamic>))
+          .toList(),
+    );
+  }
+  String toJson() => json.encode(toMap());
+
+  factory PackageDocumentation.fromJson(String source) =>
+      PackageDocumentation.fromMap(json.decode(source) as Map<String, dynamic>);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    final listEquals = const DeepCollectionEquality().equals;
+
+    return other is PackageDocumentation &&
+        other.name == name &&
+        other.latestStableVersion == latestStableVersion &&
+        listEquals(other.versions, versions);
+  }
+
+  @override
+  int get hashCode =>
+      name.hashCode ^ latestStableVersion.hashCode ^ versions.hashCode;
+}
+
+/// Package Documentation Version Model
+
+class PackageDocumentationVersion {
+  final String version;
+  final String status;
+  final bool hasDocumentation;
+  PackageDocumentationVersion({
+    required this.version,
+    required this.status,
+    required this.hasDocumentation,
+  });
+
+  Map<String, dynamic> toMap() => {
+        'version': version,
+        'status': status,
+        'hasDocumentation': hasDocumentation,
+      };
+
+  factory PackageDocumentationVersion.fromMap(Map<String, dynamic> map) =>
+      PackageDocumentationVersion(
+        version: map['version'] as String? ?? '',
+        status: map['status'] as String? ?? '',
+        hasDocumentation: map['hasDocumentation'] as bool? ?? false,
+      );
+
+  String toJson() => json.encode(toMap());
+
+  factory PackageDocumentationVersion.fromJson(String source) =>
+      PackageDocumentationVersion.fromMap(
+          json.decode(source) as Map<String, dynamic>);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is PackageDocumentationVersion &&
+        other.version == version &&
+        other.status == status &&
+        other.hasDocumentation == hasDocumentation;
+  }
+
+  @override
+  int get hashCode =>
+      version.hashCode ^ status.hashCode ^ hasDocumentation.hashCode;
+}

--- a/lib/src/pub_api_client/src/models/package_documentation_model.dart
+++ b/lib/src/pub_api_client/src/models/package_documentation_model.dart
@@ -1,27 +1,16 @@
 import 'dart:convert';
 
 import 'package:collection/collection.dart';
+import 'package:meta/meta.dart';
 
 /// Package Documentation Model
-
+@immutable
 class PackageDocumentation {
-  final String name;
-
-  final String latestStableVersion;
-
-  final List<PackageDocumentationVersion> versions;
-
   PackageDocumentation({
     required this.name,
     required this.latestStableVersion,
     this.versions = const [],
   });
-
-  Map<String, dynamic> toMap() => {
-        'name': name,
-        'latestStableVersion': latestStableVersion,
-        'versions': versions.map((x) => x.toMap()).toList(),
-      };
 
   factory PackageDocumentation.fromMap(Map<String, dynamic> map) {
     final versionMap = map['versions'] as List<dynamic>? ?? [];
@@ -35,10 +24,21 @@ class PackageDocumentation {
           .toList(),
     );
   }
-  String toJson() => json.encode(toMap());
 
   factory PackageDocumentation.fromJson(String source) =>
       PackageDocumentation.fromMap(json.decode(source) as Map<String, dynamic>);
+  final String name;
+
+  final String latestStableVersion;
+
+  final List<PackageDocumentationVersion> versions;
+
+  Map<String, dynamic> toMap() => {
+        'name': name,
+        'latestStableVersion': latestStableVersion,
+        'versions': versions.map((x) => x.toMap()).toList(),
+      };
+  String toJson() => json.encode(toMap());
 
   @override
   bool operator ==(Object other) {
@@ -57,22 +57,13 @@ class PackageDocumentation {
 }
 
 /// Package Documentation Version Model
-
+@immutable
 class PackageDocumentationVersion {
-  final String version;
-  final String status;
-  final bool hasDocumentation;
   PackageDocumentationVersion({
     required this.version,
     required this.status,
     required this.hasDocumentation,
   });
-
-  Map<String, dynamic> toMap() => {
-        'version': version,
-        'status': status,
-        'hasDocumentation': hasDocumentation,
-      };
 
   factory PackageDocumentationVersion.fromMap(Map<String, dynamic> map) =>
       PackageDocumentationVersion(
@@ -81,11 +72,20 @@ class PackageDocumentationVersion {
         hasDocumentation: map['hasDocumentation'] as bool? ?? false,
       );
 
-  String toJson() => json.encode(toMap());
-
   factory PackageDocumentationVersion.fromJson(String source) =>
       PackageDocumentationVersion.fromMap(
           json.decode(source) as Map<String, dynamic>);
+  final String version;
+  final String status;
+  final bool hasDocumentation;
+
+  Map<String, dynamic> toMap() => {
+        'version': version,
+        'status': status,
+        'hasDocumentation': hasDocumentation,
+      };
+
+  String toJson() => json.encode(toMap());
 
   @override
   bool operator ==(Object other) {

--- a/lib/src/pub_api_client/src/models/package_like_model.dart
+++ b/lib/src/pub_api_client/src/models/package_like_model.dart
@@ -1,0 +1,20 @@
+/// Package like
+
+class PackageLike {
+  final String package;
+  final bool liked;
+  const PackageLike({
+    required this.package,
+    required this.liked,
+  });
+
+  Map<String, dynamic> toMap() => {
+        'package': package,
+        'liked': liked,
+      };
+
+  factory PackageLike.fromMap(Map<String, dynamic> map) => PackageLike(
+        package: map['package'] as String? ?? '',
+        liked: map['liked'] as bool? ?? false,
+      );
+}

--- a/lib/src/pub_api_client/src/models/package_like_model.dart
+++ b/lib/src/pub_api_client/src/models/package_like_model.dart
@@ -1,20 +1,20 @@
 /// Package like
 
 class PackageLike {
-  final String package;
-  final bool liked;
   const PackageLike({
     required this.package,
     required this.liked,
   });
 
-  Map<String, dynamic> toMap() => {
-        'package': package,
-        'liked': liked,
-      };
-
   factory PackageLike.fromMap(Map<String, dynamic> map) => PackageLike(
         package: map['package'] as String? ?? '',
         liked: map['liked'] as bool? ?? false,
       );
+  final String package;
+  final bool liked;
+
+  Map<String, dynamic> toMap() => {
+        'package': package,
+        'liked': liked,
+      };
 }

--- a/lib/src/pub_api_client/src/models/package_metrics_model.dart
+++ b/lib/src/pub_api_client/src/models/package_metrics_model.dart
@@ -1,0 +1,23 @@
+import '../../pub_api_client.dart';
+
+/// Package Metrics Model
+
+class PackageMetrics {
+  final PackageScore score;
+  final PackageScoreCard scorecard;
+  const PackageMetrics({
+    required this.score,
+    required this.scorecard,
+  });
+
+  Map<String, dynamic> toMap() => {
+        'score': score.toMap(),
+        'scorecard': scorecard.toMap(),
+      };
+
+  factory PackageMetrics.fromMap(Map<String, dynamic> map) => PackageMetrics(
+        score: PackageScore.fromMap(map['score'] as Map<String, dynamic>),
+        scorecard:
+            PackageScoreCard.fromMap(map['scorecard'] as Map<String, dynamic>),
+      );
+}

--- a/lib/src/pub_api_client/src/models/package_metrics_model.dart
+++ b/lib/src/pub_api_client/src/models/package_metrics_model.dart
@@ -3,21 +3,21 @@ import '../../pub_api_client.dart';
 /// Package Metrics Model
 
 class PackageMetrics {
-  final PackageScore score;
-  final PackageScoreCard scorecard;
   const PackageMetrics({
     required this.score,
     required this.scorecard,
   });
-
-  Map<String, dynamic> toMap() => {
-        'score': score.toMap(),
-        'scorecard': scorecard.toMap(),
-      };
 
   factory PackageMetrics.fromMap(Map<String, dynamic> map) => PackageMetrics(
         score: PackageScore.fromMap(map['score'] as Map<String, dynamic>),
         scorecard:
             PackageScoreCard.fromMap(map['scorecard'] as Map<String, dynamic>),
       );
+  final PackageScore score;
+  final PackageScoreCard scorecard;
+
+  Map<String, dynamic> toMap() => {
+        'score': score.toMap(),
+        'scorecard': scorecard.toMap(),
+      };
 }

--- a/lib/src/pub_api_client/src/models/package_options_model.dart
+++ b/lib/src/pub_api_client/src/models/package_options_model.dart
@@ -1,0 +1,25 @@
+/// Package Options Model
+
+class PackageOptions {
+  final bool isDiscontinued;
+  final bool isUnlisted;
+  final String? replacedBy;
+
+  const PackageOptions({
+    this.isDiscontinued = false,
+    this.isUnlisted = false,
+    this.replacedBy,
+  });
+
+  Map<String, dynamic> toMap() => {
+        'isDiscontinued': isDiscontinued,
+        'isUnlisted': isUnlisted,
+        'replacedBy': replacedBy,
+      };
+
+  factory PackageOptions.fromMap(Map<String, dynamic> map) => PackageOptions(
+        isDiscontinued: map['isDiscontinued'] as bool? ?? false,
+        isUnlisted: map['isUnlisted'] as bool? ?? false,
+        replacedBy: map['replacedBy'] as String?,
+      );
+}

--- a/lib/src/pub_api_client/src/models/package_options_model.dart
+++ b/lib/src/pub_api_client/src/models/package_options_model.dart
@@ -1,25 +1,24 @@
 /// Package Options Model
 
 class PackageOptions {
-  final bool isDiscontinued;
-  final bool isUnlisted;
-  final String? replacedBy;
-
   const PackageOptions({
     this.isDiscontinued = false,
     this.isUnlisted = false,
     this.replacedBy,
   });
 
-  Map<String, dynamic> toMap() => {
-        'isDiscontinued': isDiscontinued,
-        'isUnlisted': isUnlisted,
-        'replacedBy': replacedBy,
-      };
-
   factory PackageOptions.fromMap(Map<String, dynamic> map) => PackageOptions(
         isDiscontinued: map['isDiscontinued'] as bool? ?? false,
         isUnlisted: map['isUnlisted'] as bool? ?? false,
         replacedBy: map['replacedBy'] as String?,
       );
+  final bool isDiscontinued;
+  final bool isUnlisted;
+  final String? replacedBy;
+
+  Map<String, dynamic> toMap() => {
+        'isDiscontinued': isDiscontinued,
+        'isUnlisted': isUnlisted,
+        'replacedBy': replacedBy,
+      };
 }

--- a/lib/src/pub_api_client/src/models/package_publisher_model.dart
+++ b/lib/src/pub_api_client/src/models/package_publisher_model.dart
@@ -1,17 +1,17 @@
 /// Package Publisher Model
 
 class PackagePublisher {
-  final String? publisherId;
   const PackagePublisher({
     this.publisherId,
   });
-
-  Map<String, dynamic> toMap() => {
-        'publisherId': publisherId,
-      };
 
   factory PackagePublisher.fromMap(Map<String, dynamic> map) =>
       PackagePublisher(
         publisherId: map['publisherId'] as String?,
       );
+  final String? publisherId;
+
+  Map<String, dynamic> toMap() => {
+        'publisherId': publisherId,
+      };
 }

--- a/lib/src/pub_api_client/src/models/package_publisher_model.dart
+++ b/lib/src/pub_api_client/src/models/package_publisher_model.dart
@@ -1,0 +1,17 @@
+/// Package Publisher Model
+
+class PackagePublisher {
+  final String? publisherId;
+  const PackagePublisher({
+    this.publisherId,
+  });
+
+  Map<String, dynamic> toMap() => {
+        'publisherId': publisherId,
+      };
+
+  factory PackagePublisher.fromMap(Map<String, dynamic> map) =>
+      PackagePublisher(
+        publisherId: map['publisherId'] as String?,
+      );
+}

--- a/lib/src/pub_api_client/src/models/package_score_model.dart
+++ b/lib/src/pub_api_client/src/models/package_score_model.dart
@@ -1,0 +1,134 @@
+import 'package:collection/collection.dart';
+
+/// Package Score Model
+class PackageScore {
+  final int? grantedPoints;
+  final int? maxPoints;
+  final int likeCount;
+  final double? popularityScore;
+  final DateTime lastUpdated;
+  const PackageScore({
+    required this.grantedPoints,
+    required this.maxPoints,
+    required this.likeCount,
+    required this.popularityScore,
+    required this.lastUpdated,
+  });
+
+  Map<String, dynamic> toMap() => {
+        'grantedPoints': grantedPoints,
+        'maxPoints': maxPoints,
+        'likeCount': likeCount,
+        'popularityScore': popularityScore,
+        'lastUpdated': lastUpdated.millisecondsSinceEpoch,
+      };
+
+  factory PackageScore.fromMap(Map<String, dynamic> map) => PackageScore(
+        grantedPoints: map['grantedPoints'] as int? ?? 0,
+        maxPoints: map['maxPoints'] as int? ?? 0,
+        likeCount: map['likeCount'] as int? ?? 0,
+        popularityScore: map['popularityScore'] as double? ?? 0.0,
+        lastUpdated: DateTime.parse(map['lastUpdated'] as String? ?? ''),
+      );
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is PackageScore &&
+        other.grantedPoints == grantedPoints &&
+        other.maxPoints == maxPoints &&
+        other.likeCount == likeCount &&
+        other.popularityScore == popularityScore &&
+        other.lastUpdated == lastUpdated;
+  }
+
+  @override
+  int get hashCode =>
+      grantedPoints.hashCode ^
+      maxPoints.hashCode ^
+      likeCount.hashCode ^
+      popularityScore.hashCode ^
+      lastUpdated.hashCode;
+}
+
+/// Package Score Card Model
+class PackageScoreCard {
+  final String packageName;
+  final String packageVersion;
+  final String runtimeVersion;
+  final DateTime updated;
+  final DateTime packageCreated;
+  final DateTime packageVersionCreated;
+  final List<String> derivedTags;
+  final List<String> flags;
+  final List<String> reportTypes;
+  const PackageScoreCard({
+    required this.packageName,
+    required this.packageVersion,
+    required this.runtimeVersion,
+    required this.updated,
+    required this.packageCreated,
+    required this.packageVersionCreated,
+    this.derivedTags = const [],
+    this.flags = const [],
+    this.reportTypes = const [],
+  });
+
+  Map<String, dynamic> toMap() => {
+        'packageName': packageName,
+        'packageVersion': packageVersion,
+        'runtimeVersion': runtimeVersion,
+        'updated': updated.millisecondsSinceEpoch,
+        'packageCreated': packageCreated.millisecondsSinceEpoch,
+        'packageVersionCreated': packageVersionCreated.millisecondsSinceEpoch,
+        'derivedTags': derivedTags,
+        'flags': flags,
+        'reportTypes': reportTypes,
+      };
+
+  factory PackageScoreCard.fromMap(Map<String, dynamic> map) =>
+      PackageScoreCard(
+        packageName: map['packageName'] as String? ?? '',
+        packageVersion: map['packageVersion'] as String? ?? '',
+        runtimeVersion: map['runtimeVersion'] as String? ?? '',
+        updated: DateTime.parse(map['updated'] as String? ?? ''),
+        packageCreated: DateTime.parse(map['packageCreated'] as String? ?? ''),
+        packageVersionCreated:
+            DateTime.parse(map['packageVersionCreated'] as String? ?? ''),
+        derivedTags:
+            List<String>.from(map['derivedTags'] as List<dynamic>? ?? []),
+        flags: List<String>.from(map['flags'] as List<dynamic>? ?? []),
+        reportTypes:
+            List<String>.from(map['reportTypes'] as List<dynamic>? ?? []),
+      );
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    final listEquals = const DeepCollectionEquality().equals;
+
+    return other is PackageScoreCard &&
+        other.packageName == packageName &&
+        other.packageVersion == packageVersion &&
+        other.runtimeVersion == runtimeVersion &&
+        other.updated == updated &&
+        other.packageCreated == packageCreated &&
+        other.packageVersionCreated == packageVersionCreated &&
+        listEquals(other.derivedTags, derivedTags) &&
+        listEquals(other.flags, flags) &&
+        listEquals(other.reportTypes, reportTypes);
+  }
+
+  @override
+  int get hashCode =>
+      packageName.hashCode ^
+      packageVersion.hashCode ^
+      runtimeVersion.hashCode ^
+      updated.hashCode ^
+      packageCreated.hashCode ^
+      packageVersionCreated.hashCode ^
+      derivedTags.hashCode ^
+      flags.hashCode ^
+      reportTypes.hashCode;
+}

--- a/lib/src/pub_api_client/src/models/package_score_model.dart
+++ b/lib/src/pub_api_client/src/models/package_score_model.dart
@@ -1,12 +1,9 @@
 import 'package:collection/collection.dart';
+import 'package:meta/meta.dart';
 
 /// Package Score Model
+@immutable
 class PackageScore {
-  final int? grantedPoints;
-  final int? maxPoints;
-  final int likeCount;
-  final double? popularityScore;
-  final DateTime lastUpdated;
   const PackageScore({
     required this.grantedPoints,
     required this.maxPoints,
@@ -15,14 +12,6 @@ class PackageScore {
     required this.lastUpdated,
   });
 
-  Map<String, dynamic> toMap() => {
-        'grantedPoints': grantedPoints,
-        'maxPoints': maxPoints,
-        'likeCount': likeCount,
-        'popularityScore': popularityScore,
-        'lastUpdated': lastUpdated.millisecondsSinceEpoch,
-      };
-
   factory PackageScore.fromMap(Map<String, dynamic> map) => PackageScore(
         grantedPoints: map['grantedPoints'] as int? ?? 0,
         maxPoints: map['maxPoints'] as int? ?? 0,
@@ -30,6 +19,19 @@ class PackageScore {
         popularityScore: map['popularityScore'] as double? ?? 0.0,
         lastUpdated: DateTime.parse(map['lastUpdated'] as String? ?? ''),
       );
+  final int? grantedPoints;
+  final int? maxPoints;
+  final int likeCount;
+  final double? popularityScore;
+  final DateTime lastUpdated;
+
+  Map<String, dynamic> toMap() => {
+        'grantedPoints': grantedPoints,
+        'maxPoints': maxPoints,
+        'likeCount': likeCount,
+        'popularityScore': popularityScore,
+        'lastUpdated': lastUpdated.millisecondsSinceEpoch,
+      };
 
   @override
   bool operator ==(Object other) {
@@ -53,16 +55,8 @@ class PackageScore {
 }
 
 /// Package Score Card Model
+@immutable
 class PackageScoreCard {
-  final String packageName;
-  final String packageVersion;
-  final String runtimeVersion;
-  final DateTime updated;
-  final DateTime packageCreated;
-  final DateTime packageVersionCreated;
-  final List<String> derivedTags;
-  final List<String> flags;
-  final List<String> reportTypes;
   const PackageScoreCard({
     required this.packageName,
     required this.packageVersion,
@@ -74,18 +68,6 @@ class PackageScoreCard {
     this.flags = const [],
     this.reportTypes = const [],
   });
-
-  Map<String, dynamic> toMap() => {
-        'packageName': packageName,
-        'packageVersion': packageVersion,
-        'runtimeVersion': runtimeVersion,
-        'updated': updated.millisecondsSinceEpoch,
-        'packageCreated': packageCreated.millisecondsSinceEpoch,
-        'packageVersionCreated': packageVersionCreated.millisecondsSinceEpoch,
-        'derivedTags': derivedTags,
-        'flags': flags,
-        'reportTypes': reportTypes,
-      };
 
   factory PackageScoreCard.fromMap(Map<String, dynamic> map) =>
       PackageScoreCard(
@@ -102,6 +84,27 @@ class PackageScoreCard {
         reportTypes:
             List<String>.from(map['reportTypes'] as List<dynamic>? ?? []),
       );
+  final String packageName;
+  final String packageVersion;
+  final String runtimeVersion;
+  final DateTime updated;
+  final DateTime packageCreated;
+  final DateTime packageVersionCreated;
+  final List<String> derivedTags;
+  final List<String> flags;
+  final List<String> reportTypes;
+
+  Map<String, dynamic> toMap() => {
+        'packageName': packageName,
+        'packageVersion': packageVersion,
+        'runtimeVersion': runtimeVersion,
+        'updated': updated.millisecondsSinceEpoch,
+        'packageCreated': packageCreated.millisecondsSinceEpoch,
+        'packageVersionCreated': packageVersionCreated.millisecondsSinceEpoch,
+        'derivedTags': derivedTags,
+        'flags': flags,
+        'reportTypes': reportTypes,
+      };
 
   @override
   bool operator ==(Object other) {

--- a/lib/src/pub_api_client/src/models/pub_package_model.dart
+++ b/lib/src/pub_api_client/src/models/pub_package_model.dart
@@ -1,0 +1,68 @@
+import 'package:pubspec/pubspec.dart';
+
+/// Package Model
+class PubPackage {
+  final String name;
+  final PackageVersion latest;
+  final List<PackageVersion> versions;
+  const PubPackage({
+    required this.name,
+    required this.latest,
+    this.versions = const [],
+  });
+
+  String get version => latest.version;
+  String get description => latestPubspec.description ?? '';
+  String get url => 'https://pub.dev/packages/$name';
+  String get changelogUrl => '$url/changelog';
+  PubSpec get latestPubspec => latest.pubspec;
+
+  Map<String, dynamic> toMap() => {
+        'name': name,
+        'latest': latest.toMap(),
+        'versions': versions.map((x) => x.toMap()).toList(),
+      };
+
+  factory PubPackage.fromMap(Map<String, dynamic> map) {
+    final versionMap = map['versions'] as List<dynamic>? ?? [];
+    return PubPackage(
+      name: map['name'] as String? ?? '',
+      latest:
+          PackageVersion.fromMap(map['latest'] as Map<String, dynamic>? ?? {}),
+      versions: List<PackageVersion>.from(
+        versionMap.map(
+          (x) => PackageVersion.fromMap(x as Map<String, dynamic>),
+        ),
+      ),
+    );
+  }
+}
+
+/// Package Version Model
+class PackageVersion {
+  final String version;
+  final PubSpec pubspec;
+  final String archiveUrl;
+  final DateTime published;
+  const PackageVersion({
+    required this.version,
+    required this.pubspec,
+    required this.archiveUrl,
+    required this.published,
+  });
+
+  Map<String, dynamic> toMap() => {
+        'version': version,
+        'pubspec': pubspec.toJson(),
+        'archiveUrl': archiveUrl,
+        'published': published.millisecondsSinceEpoch,
+      };
+
+  factory PackageVersion.fromMap(Map<String, dynamic> map) => PackageVersion(
+        version: map['version'] as String? ?? '',
+        pubspec:
+            PubSpec.fromJson(map['pubspec'] as Map<String, dynamic>? ?? {}),
+        archiveUrl: map['archiveUrl'] as String? ?? '',
+        published: DateTime.parse(map['published'] as String? ?? ''),
+      );
+}

--- a/lib/src/pub_api_client/src/models/pub_package_model.dart
+++ b/lib/src/pub_api_client/src/models/pub_package_model.dart
@@ -2,26 +2,11 @@ import 'package:pubspec/pubspec.dart';
 
 /// Package Model
 class PubPackage {
-  final String name;
-  final PackageVersion latest;
-  final List<PackageVersion> versions;
   const PubPackage({
     required this.name,
     required this.latest,
     this.versions = const [],
   });
-
-  String get version => latest.version;
-  String get description => latestPubspec.description ?? '';
-  String get url => 'https://pub.dev/packages/$name';
-  String get changelogUrl => '$url/changelog';
-  PubSpec get latestPubspec => latest.pubspec;
-
-  Map<String, dynamic> toMap() => {
-        'name': name,
-        'latest': latest.toMap(),
-        'versions': versions.map((x) => x.toMap()).toList(),
-      };
 
   factory PubPackage.fromMap(Map<String, dynamic> map) {
     final versionMap = map['versions'] as List<dynamic>? ?? [];
@@ -36,27 +21,31 @@ class PubPackage {
       ),
     );
   }
+  final String name;
+  final PackageVersion latest;
+  final List<PackageVersion> versions;
+
+  String get version => latest.version;
+  String get description => latestPubspec.description ?? '';
+  String get url => 'https://pub.dev/packages/$name';
+  String get changelogUrl => '$url/changelog';
+  PubSpec get latestPubspec => latest.pubspec;
+
+  Map<String, dynamic> toMap() => {
+        'name': name,
+        'latest': latest.toMap(),
+        'versions': versions.map((x) => x.toMap()).toList(),
+      };
 }
 
 /// Package Version Model
 class PackageVersion {
-  final String version;
-  final PubSpec pubspec;
-  final String archiveUrl;
-  final DateTime published;
   const PackageVersion({
     required this.version,
     required this.pubspec,
     required this.archiveUrl,
     required this.published,
   });
-
-  Map<String, dynamic> toMap() => {
-        'version': version,
-        'pubspec': pubspec.toJson(),
-        'archiveUrl': archiveUrl,
-        'published': published.millisecondsSinceEpoch,
-      };
 
   factory PackageVersion.fromMap(Map<String, dynamic> map) => PackageVersion(
         version: map['version'] as String? ?? '',
@@ -65,4 +54,15 @@ class PackageVersion {
         archiveUrl: map['archiveUrl'] as String? ?? '',
         published: DateTime.parse(map['published'] as String? ?? ''),
       );
+  final String version;
+  final PubSpec pubspec;
+  final String archiveUrl;
+  final DateTime published;
+
+  Map<String, dynamic> toMap() => {
+        'version': version,
+        'pubspec': pubspec.toJson(),
+        'archiveUrl': archiveUrl,
+        'published': published.millisecondsSinceEpoch,
+      };
 }

--- a/lib/src/pub_api_client/src/models/search_order.dart
+++ b/lib/src/pub_api_client/src/models/search_order.dart
@@ -1,0 +1,32 @@
+enum SearchOrder {
+  /// Search score should be a weighted value of [text], [popularity], [points]
+  /// and [like], ordered decreasing.
+  top,
+
+  /// Search score should depend only on text match similarity, ordered
+  /// decreasing.
+  text,
+
+  /// Search order should be in decreasing last package creation time.
+  created,
+
+  /// Search order should be in decreasing last package updated time.
+  updated,
+
+  /// Search order should be in decreasing popularity score.
+  popularity,
+
+  /// Search order should be in decreasing like count.
+  like,
+
+  /// Search order should be in decreasing pub points.
+  points,
+}
+
+extension SearchOrderExtension on SearchOrder {
+  /// Name of the channel
+  String get value {
+    final self = this;
+    return self.toString().split('.').last;
+  }
+}

--- a/lib/src/pub_api_client/src/models/search_results_model.dart
+++ b/lib/src/pub_api_client/src/models/search_results_model.dart
@@ -1,0 +1,65 @@
+import 'package:collection/collection.dart';
+
+/// Search Results Model
+class SearchResults {
+  final List<PackageResult> packages;
+  final String? next;
+  const SearchResults({
+    required this.packages,
+    this.next,
+  });
+
+  Map<String, dynamic> toMap() => {
+        'packages': packages.map((x) => x.toMap()).toList(),
+        'next': next,
+      };
+
+  factory SearchResults.fromMap(Map<String, dynamic> map) {
+    final packagesMap = map['packages'] as List<dynamic>? ?? [];
+    return SearchResults(
+      packages: List<PackageResult>.from(
+        packagesMap.map(
+          (x) => PackageResult.fromMap(x as Map<String, dynamic>),
+        ),
+      ),
+      next: map['next'] as String?,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    final listEquals = const DeepCollectionEquality().equals;
+
+    return other is SearchResults &&
+        listEquals(other.packages, packages) &&
+        other.next == next;
+  }
+
+  @override
+  int get hashCode => packages.hashCode ^ next.hashCode;
+}
+
+/// Package Result Model returns within a `SearchResult`
+class PackageResult {
+  final String package;
+  const PackageResult({required this.package});
+
+  Map<String, dynamic> toMap() => {
+        'package': package,
+      };
+
+  factory PackageResult.fromMap(Map<String, dynamic> map) => PackageResult(
+        package: map['package'] as String? ?? '',
+      );
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is PackageResult && other.package == package;
+  }
+
+  @override
+  int get hashCode => package.hashCode;
+}

--- a/lib/src/pub_api_client/src/models/search_results_model.dart
+++ b/lib/src/pub_api_client/src/models/search_results_model.dart
@@ -1,18 +1,13 @@
 import 'package:collection/collection.dart';
+import 'package:meta/meta.dart';
 
 /// Search Results Model
+@immutable
 class SearchResults {
-  final List<PackageResult> packages;
-  final String? next;
   const SearchResults({
     required this.packages,
     this.next,
   });
-
-  Map<String, dynamic> toMap() => {
-        'packages': packages.map((x) => x.toMap()).toList(),
-        'next': next,
-      };
 
   factory SearchResults.fromMap(Map<String, dynamic> map) {
     final packagesMap = map['packages'] as List<dynamic>? ?? [];
@@ -25,6 +20,13 @@ class SearchResults {
       next: map['next'] as String?,
     );
   }
+  final List<PackageResult> packages;
+  final String? next;
+
+  Map<String, dynamic> toMap() => {
+        'packages': packages.map((x) => x.toMap()).toList(),
+        'next': next,
+      };
 
   @override
   bool operator ==(Object other) {
@@ -41,17 +43,18 @@ class SearchResults {
 }
 
 /// Package Result Model returns within a `SearchResult`
+@immutable
 class PackageResult {
-  final String package;
   const PackageResult({required this.package});
-
-  Map<String, dynamic> toMap() => {
-        'package': package,
-      };
 
   factory PackageResult.fromMap(Map<String, dynamic> map) => PackageResult(
         package: map['package'] as String? ?? '',
       );
+  final String package;
+
+  Map<String, dynamic> toMap() => {
+        'package': package,
+      };
 
   @override
   bool operator ==(Object other) {

--- a/lib/src/pub_api_client/src/pub_api_client_base.dart
+++ b/lib/src/pub_api_client/src/pub_api_client_base.dart
@@ -22,11 +22,6 @@ typedef FetchFunction = Future<Map<String, dynamic>> Function(String url);
 
 /// Pub API Client
 class PubClient {
-  final Endpoint endpoint;
-  final String? pubUrl;
-  final http.Client? client;
-  final Credentials? credentials;
-  late final PubApiHttpClient _client;
   PubClient({
     this.pubUrl,
     this.credentials,
@@ -48,6 +43,11 @@ class PubClient {
       // credentials: credentials,
     );
   }
+  final Endpoint endpoint;
+  final String? pubUrl;
+  final http.Client? client;
+  final Credentials? credentials;
+  late final PubApiHttpClient _client;
 
   Future<Map<String, dynamic>> _fetch(String url) async {
     final response = await _client.get(Uri.parse(url));

--- a/lib/src/pub_api_client/src/pub_api_client_base.dart
+++ b/lib/src/pub_api_client/src/pub_api_client_base.dart
@@ -1,0 +1,237 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+import 'package:oauth2/oauth2.dart';
+
+import 'constants.dart';
+import 'endpoints.dart';
+import 'helpers/exceptions.dart';
+import 'helpers/http_client.dart';
+import 'helpers/recursive_paging.dart';
+import 'models/package_documentation_model.dart';
+import 'models/package_like_model.dart';
+import 'models/package_metrics_model.dart';
+import 'models/package_options_model.dart';
+import 'models/package_publisher_model.dart';
+import 'models/package_score_model.dart';
+import 'models/pub_package_model.dart';
+import 'models/search_order.dart';
+import 'models/search_results_model.dart';
+
+typedef FetchFunction = Future<Map<String, dynamic>> Function(String url);
+
+/// Pub API Client
+class PubClient {
+  final Endpoint endpoint;
+  final String? pubUrl;
+  final http.Client? client;
+  final Credentials? credentials;
+  late final PubApiHttpClient _client;
+  PubClient({
+    this.pubUrl,
+    this.credentials,
+    this.client,
+  }) : endpoint = Endpoint(pubUrl) {
+    http.Client httpClient;
+    if (credentials == null) {
+      httpClient = http.Client();
+    } else {
+      httpClient = Client(
+        credentials!,
+        identifier: PubAuth.identifier,
+        secret: PubAuth.secret,
+      );
+    }
+
+    _client = PubApiHttpClient(
+      client ?? httpClient,
+      // credentials: credentials,
+    );
+  }
+
+  Future<Map<String, dynamic>> _fetch(String url) async {
+    final response = await _client.get(Uri.parse(url));
+    responseValidOrThrow(response);
+    return jsonDecode(response.body) as Map<String, dynamic>;
+  }
+
+  Future<Map<String, dynamic>> _put(String url) async {
+    final response = await _client.put(Uri.parse(url));
+    responseValidOrThrow(response);
+    return jsonDecode(response.body) as Map<String, dynamic>;
+  }
+
+  Future<void> _delete(String url) async {
+    final response = await _client.delete(Uri.parse(url));
+    responseValidOrThrow(response);
+  }
+
+  /// Returns the `PubPackage` information for [packageName]
+  Future<PubPackage> packageInfo(String packageName) async {
+    final data = await _fetch(endpoint.packageInfo(packageName));
+    return PubPackage.fromMap(data);
+  }
+
+  /// Returns the `PackageScore` for package [packageName]
+  Future<PackageScore> packageScore(String packageName) async {
+    final data = await _fetch(endpoint.packageScore(packageName));
+    return PackageScore.fromMap(data);
+  }
+
+  /// Returns the `PackageMetrics` for package [packageName]
+  Future<PackageMetrics?> packageMetrics(String packageName) async {
+    try {
+      final data = await _fetch(endpoint.packageMetrics(packageName));
+      return PackageMetrics.fromMap(data);
+    } on NotFoundException {
+      // If the package has not been scanned, the server will return 404
+      return null;
+    }
+  }
+
+  /// Returns the `PackageOptions` for package [packageName]
+  Future<PackageOptions> packageOptions(String packageName) async {
+    final data = await _fetch(endpoint.packageOptions(packageName));
+
+    return PackageOptions.fromMap(data);
+  }
+
+  /// Returns the `PackagePublisher` for package [packageName]
+  Future<PackagePublisher> packagePublisher(String packageName) async {
+    final data = await _fetch(endpoint.packagePublisher(packageName));
+    return PackagePublisher.fromMap(data);
+  }
+
+  /// Returns a list of versions that are published for package [packageName]
+  Future<List<String>> packageVersions(String packageName) async {
+    final data = await _fetch(endpoint.packageVersions(packageName));
+    final json = data;
+    final versions = <String>[];
+    for (var version in json['versions'] as List) {
+      versions.add(version as String);
+    }
+    return versions;
+  }
+
+  /// Returns `PackageVersion` of an specific [packageName];
+  Future<PackageVersion> packageVersionInfo(
+      String packageName, String version) async {
+    final data =
+        await _fetch(endpoint.packageVersionInfo(packageName, version));
+    return PackageVersion.fromMap(data);
+  }
+
+  /// Returns a `List<String>` of all packages listed on pub.dev
+  Future<List<String>> packageNameCompletion() async {
+    final data = await _fetch(endpoint.packageNames);
+    final packages = data['packages'] as List<dynamic>;
+
+    /// Need to map to convert dynamic into String
+    return packages.map((item) => item as String).toList();
+  }
+
+  /// Searches pub for [query] and can [page] results.
+  /// Can specify [tags] to filter results. See [PackageTag] for details.
+  /// returns `SearchResults`
+  Future<SearchResults> search(
+    String query, {
+    int page = 1,
+    SearchOrder sort = SearchOrder.top,
+    List<String> tags = const [],
+  }) async {
+    final buffer = StringBuffer(query);
+    for (final tag in tags) {
+      buffer.write(' $tag');
+    }
+    final data = await _fetch(endpoint.search(buffer.toString(), page, sort));
+    return SearchResults.fromMap(data);
+  }
+
+  /// Receives [nextPageUrl]
+  /// returns `SearchResults`
+  Future<SearchResults> nextPage(String nextPageUrl) async {
+    final data = await _fetch(endpoint.nextPage(nextPageUrl));
+    return SearchResults.fromMap(data);
+  }
+
+  /// Returns `PackageDocumentation` for a [packageName]
+  Future<PackageDocumentation> documentation(String packageName) async {
+    final data = await _fetch(endpoint.packageDocumentation(packageName));
+    return PackageDocumentation.fromMap(data);
+  }
+
+  /// Displays like status of a package
+  Future<PackageLike> likePackageStatus(String name) async {
+    final data = await _fetch(endpoint.likePackage(name));
+    return PackageLike.fromMap(data);
+  }
+
+  /// Likes a package
+  Future<PackageLike> likePackage(String name) async {
+    final data = await _put(endpoint.likePackage(name));
+    return PackageLike.fromMap(data);
+  }
+
+  /// Unlikes a package
+  Future<void> unlikePackage(String name) =>
+      _delete(endpoint.likePackage(name));
+
+  /// List package likes
+  Future<List<PackageLike>> listPackageLikes() async {
+    final response = await _fetch(endpoint.likedPackages);
+
+    final likes = response['likedPackages'] as List<dynamic>;
+    return likes
+        .map((like) => PackageLike.fromMap(like as Map<String, dynamic>))
+        .toList();
+  }
+
+  /// Retrieves all Google packages from pub.dev
+  /// Mostly used as an internal tool to generate
+  /// google_packages_list.dart
+  /// You should probably use that instead
+  Future<List<String>> fetchGooglePackages({
+    List<String> tags = const [],
+  }) async {
+    /// List of Google publishers on pub.dev
+    const _publishers = [
+      'flutter.dev',
+      'dart.dev',
+      'material.io',
+      'firebase.google.com',
+      'google.dev',
+      'tools.dart.dev ',
+    ];
+
+    final futures = <Future<List<PackageResult>>>[];
+    for (var publisher in _publishers) {
+      futures.add(fetchPublisherPackages(publisher, tags: tags));
+    }
+    final results = await Future.wait(futures);
+    final flatResults = results.expand((r) => r).toList();
+    return flatResults.map((r) => r.package).toList();
+  }
+
+  /// Retrieves all the flutter favorites
+  Future<List<String>> fetchFlutterFavorites() async {
+    final searchResults =
+        await search('', tags: [PackageTag.isFlutterFavorite]);
+    final results = await recursivePaging(this, searchResults);
+    return results.map((r) => r.package).toList();
+  }
+
+  Future<List<PackageResult>> fetchPublisherPackages(
+    String publisherName, {
+    List<String> tags = const [],
+  }) async {
+    final results = await search('', tags: [
+      PackageTag.publisher(publisherName),
+      ...tags,
+    ]);
+    return recursivePaging(this, results);
+  }
+
+  void close() {
+    client?.close();
+  }
+}

--- a/lib/src/pub_api_client/src/schemas/package_metrics_schema.json
+++ b/lib/src/pub_api_client/src/schemas/package_metrics_schema.json
@@ -1,0 +1,100 @@
+{
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "$ref": "#/definitions/PackageMetrics",
+  "definitions": {
+    "PackageMetrics": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "score": {
+          "$ref": "#/definitions/Score"
+        },
+        "scorecard": {
+          "$ref": "#/definitions/Scorecard"
+        }
+      },
+      "required": [],
+      "title": "PackageMetrics"
+    },
+    "Score": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "grantedPoints": {
+          "type": "integer"
+        },
+        "maxPoints": {
+          "type": "integer"
+        },
+        "likeCount": {
+          "type": "integer"
+        },
+        "popularityScore": {
+          "type": "number"
+        },
+        "lastUpdated": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "required": [],
+      "title": "Score"
+    },
+    "Scorecard": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "packageName": {
+          "type": "string"
+        },
+        "packageVersion": {
+          "type": "string"
+        },
+        "runtimeVersion": {
+          "type": "string"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "packageCreated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "packageVersionCreated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "grantedPubPoints": {
+          "type": "integer"
+        },
+        "maxPubPoints": {
+          "type": "integer"
+        },
+        "popularityScore": {
+          "type": "number"
+        },
+        "derivedTags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "flags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "reportTypes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [],
+      "title": "Scorecard"
+    }
+  }
+}

--- a/lib/src/pub_api_client/src/schemas/package_options_schema.json
+++ b/lib/src/pub_api_client/src/schemas/package_options_schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "$ref": "#/definitions/PackageOptions",
+  "definitions": {
+    "PackageOptions": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "isDiscontinued": {
+          "type": "boolean"
+        },
+        "replacedBy": {
+          "type": "string"
+        },
+        "isUnlisted": {
+          "type": "boolean"
+        }
+      },
+      "required": [],
+      "title": "PackageOptions"
+    }
+  }
+}

--- a/lib/src/pub_api_client/src/schemas/package_score_schema.json
+++ b/lib/src/pub_api_client/src/schemas/package_score_schema.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "$ref": "#/definitions/PackageScore",
+  "definitions": {
+    "PackageScore": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "grantedPoints": {
+          "type": "integer"
+        },
+        "maxPoints": {
+          "type": "integer"
+        },
+        "likeCount": {
+          "type": "integer"
+        },
+        "popularityScore": {
+          "type": "number"
+        },
+        "lastUpdated": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "required": [],
+      "title": "PackageScore"
+    }
+  }
+}

--- a/lib/src/pub_api_client/src/schemas/package_version_schema.json
+++ b/lib/src/pub_api_client/src/schemas/package_version_schema.json
@@ -1,0 +1,196 @@
+{
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "$ref": "#/definitions/PackageVersion",
+  "definitions": {
+    "PackageVersion": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "version": {
+          "type": "string"
+        },
+        "pubspec": {
+          "$ref": "#/definitions/Pubspec"
+        },
+        "archive_url": {
+          "type": "string",
+          "format": "uri",
+          "qt-uri-protocols": ["https"],
+          "qt-uri-extensions": [".gz"]
+        },
+        "published": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "required": [],
+      "title": "PackageVersion"
+    },
+    "Pubspec": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        },
+        "homepage": {
+          "type": "string",
+          "format": "uri",
+          "qt-uri-protocols": ["https"]
+        },
+        "environment": {
+          "$ref": "#/definitions/Environment"
+        },
+        "executables": {
+          "$ref": "#/definitions/Executables"
+        },
+        "dependencies": {
+          "$ref": "#/definitions/Dependencies"
+        },
+        "dev_dependencies": {
+          "$ref": "#/definitions/DevDependencies"
+        }
+      },
+      "required": [],
+      "title": "Pubspec"
+    },
+    "Dependencies": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "meta": {
+          "type": "string"
+        },
+        "pretty_json": {
+          "type": "string"
+        },
+        "pubspec_yaml": {
+          "type": "string"
+        },
+        "args": {
+          "type": "string"
+        },
+        "cli_util": {
+          "type": "string"
+        },
+        "console": {
+          "type": "string"
+        },
+        "io": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        },
+        "process_run": {
+          "type": "string"
+        },
+        "http": {
+          "type": "string"
+        },
+        "date_format": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        },
+        "cli_dialog": {
+          "type": "string"
+        }
+      },
+      "required": [],
+      "title": "Dependencies"
+    },
+    "DevDependencies": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "pedantic": {
+          "type": "string"
+        },
+        "test": {
+          "type": "string"
+        },
+        "test_coverage": {
+          "type": "string"
+        },
+        "build_runner": {
+          "type": "string"
+        },
+        "build_version": {
+          "type": "string"
+        },
+        "build_test": {
+          "type": "string"
+        },
+        "grinder": {
+          "type": "string"
+        },
+        "cli_pkg": {
+          "$ref": "#/definitions/CLIPkg"
+        },
+        "dotenv": {
+          "type": "string"
+        }
+      },
+      "required": [],
+      "title": "DevDependencies"
+    },
+    "CLIPkg": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "git": {
+          "$ref": "#/definitions/Git"
+        }
+      },
+      "required": [],
+      "title": "CLIPkg"
+    },
+    "Git": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "qt-uri-protocols": ["https"],
+          "qt-uri-extensions": [".git"]
+        },
+        "ref": {
+          "type": "string"
+        }
+      },
+      "required": [],
+      "title": "Git"
+    },
+    "Environment": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "sdk": {
+          "type": "string"
+        }
+      },
+      "required": [],
+      "title": "Environment"
+    },
+    "Executables": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "fvm": {
+          "type": "string"
+        }
+      },
+      "required": [],
+      "title": "Executables"
+    }
+  }
+}

--- a/lib/src/pub_api_client/src/version.dart
+++ b/lib/src/pub_api_client/src/version.dart
@@ -1,0 +1,2 @@
+// Generated code. Do not modify.
+const packageVersion = '2.4.0';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'dart_dependency_updater'
 description: 'A package that will scan for dependencies in a Dart repo, update them if needed, and can update the repo with them.'
-version: '1.1.0'
-homepage: 'https://github.com/peiffer-innovations/actions_dart_dependency_updater'
+version: '1.1.1'
+homepage: 'https://github.com/peiffer-innovations/actions-dart-dependency-updater'
 
 environment:
   sdk: '>=3.0.0 <4.0.0'
@@ -13,7 +13,7 @@ dependencies:
   intl: '^0.18.1'
   json_class: '^3.0.0'
   logging: '^1.2.0'
-  meta: '^1.9.1'
+  meta: '^1.10.0'
   oauth2: '^2.0.2'
   pub_semver: '^2.1.4'
   pubspec: '^2.3.0'
@@ -46,5 +46,6 @@ ignore_updates:
   - 'term_glyph'
   - 'test_api'
   - 'typed_data'
+  - 'uuid'
   - 'vector_math'
   - 'webdriver'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
   github: '^9.16.0'
   http: '^1.1.0'
   intl: '^0.18.1'
+  json_class: '^3.0.0'
   logging: '^1.2.0'
   meta: '^1.9.1'
   oauth2: '^2.0.2'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,28 +1,28 @@
 name: 'dart_dependency_updater'
 description: 'A package that will scan for dependencies in a Dart repo, update them if needed, and can update the repo with them.'
-version: '1.0.22+22'
+version: '1.0.22+23'
 homepage: 'https://github.com/peiffer-innovations/actions_dart_dependency_updater'
 
-environment:
+environment: 
   sdk: '>=3.0.0 <4.0.0'
 
-dependencies:
-  args: '^2.4.1'
-  github: '^9.14.0'
-  http: '^0.13.6'
+dependencies: 
+  args: '^2.4.2'
+  github: '^9.16.0'
+  http: '^1.1.0'
   intl: '^0.18.1'
-  json_class: '^2.2.1+3'
-  logging: '^1.1.1'
+  json_class: '^3.0.0'
+  logging: '^1.2.0'
   meta: '^1.9.1'
   pub_api_client: '^2.4.0'
   pub_semver: '^2.1.4'
   yaml: '^3.1.2'
   yaml_writer: '^1.0.3'
 
-dev_dependencies:
-  test: '^1.24.2'
+dev_dependencies: 
+  test: '^1.24.4'
 
-ignore_updates:
+ignore_updates: 
   - 'archive'
   - 'async'
   - 'boolean_selector'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,28 +1,28 @@
 name: 'dart_dependency_updater'
 description: 'A package that will scan for dependencies in a Dart repo, update them if needed, and can update the repo with them.'
-version: '1.0.22+23'
+version: '1.1.0'
 homepage: 'https://github.com/peiffer-innovations/actions_dart_dependency_updater'
 
-environment: 
+environment:
   sdk: '>=3.0.0 <4.0.0'
 
-dependencies: 
+dependencies:
   args: '^2.4.2'
   github: '^9.16.0'
   http: '^1.1.0'
   intl: '^0.18.1'
-  json_class: '^3.0.0'
   logging: '^1.2.0'
   meta: '^1.9.1'
-  pub_api_client: '^2.4.0'
+  oauth2: '^2.0.2'
   pub_semver: '^2.1.4'
+  pubspec: '^2.3.0'
   yaml: '^3.1.2'
   yaml_writer: '^1.0.3'
 
-dev_dependencies: 
+dev_dependencies:
   test: '^1.24.4'
 
-ignore_updates: 
+ignore_updates:
   - 'archive'
   - 'async'
   - 'boolean_selector'


### PR DESCRIPTION
PR created automatically


dependencies:
  * `args`: 2.4.1 --> 2.4.2
  * `github`: 9.14.0 --> 9.16.0
  * `http`: 0.13.6 --> 1.1.0
  * `json_class`: 2.2.1+3 --> 3.0.0
  * `logging`: 1.1.1 --> 1.2.0

dev_dependencies:
  * `test`: 1.24.2 --> 1.24.4


Error!!!
```
Resolving dependencies...


Because pub_api_client >=2.3.0 depends on http ^0.13.5 and dart_dependency_updater depends on http ^1.1.0, pub_api_client >=2.3.0 is forbidden.
So, because dart_dependency_updater depends on pub_api_client ^2.4.0, version solving failed.

```

